### PR TITLE
Add support to call `start_transaction` function

### DIFF
--- a/PyMysqlPool/db_util/mysql_pool.py
+++ b/PyMysqlPool/db_util/mysql_pool.py
@@ -55,4 +55,11 @@ def get_pool_conn_implicitly(_db_config):
                                db=config['db'],
                                charset=config['charset'],
                                use_unicode=True)
+
+    conn.start_transaction(
+        consistent_snapshot=config.get('consistent_snapshot', False),
+        isolation_level=config.get('isolation_level', None),
+        readonly=config.get('readonly', None),
+    )
+
     return conn

--- a/PyMysqlPool/mysql/connector/__init__.py
+++ b/PyMysqlPool/mysql/connector/__init__.py
@@ -103,9 +103,11 @@ def _get_failover_connection(**kwargs):
         raise ValueError('failover argument not provided')
     del config['failover']
 
-    support_cnx_args = set(
-        ['user', 'password', 'host', 'port', 'unix_socket',
-         'database', 'pool_name', 'pool_size'])
+    support_cnx_args = set([
+        'user', 'password', 'host', 'port', 'unix_socket',
+        'database', 'pool_name', 'pool_size', 'consistent_snapshot',
+        'init_command', 'readonly'
+    ])
 
     # First check if we can add all use the configuration
     for server in failover:

--- a/PyMysqlPool/mysql/connector/django/base.py
+++ b/PyMysqlPool/mysql/connector/django/base.py
@@ -419,6 +419,12 @@ class DatabaseWrapper(BaseDatabaseWrapper):
             conn_params['converter_class'] = DjangoMySQLConverter
         cnx = PyMysqlPool.mysql.connector.connect(**conn_params)
 
+        cnx.start_transaction(
+            consistent_snapshot=conn_params.get('consistent_snapshot', False),
+            isolation_level=conn_params.get('isolation_level', None),
+            readonly=conn_params.get('readonly', None),
+        )
+
         return cnx
 
     def init_connection_state(self):

--- a/PyMysqlPool/mysql/connector/fabric/connection.py
+++ b/PyMysqlPool/mysql/connector/fabric/connection.py
@@ -1486,6 +1486,11 @@ class MySQLFabricConnection(object):
             dbconfig['port'] = mysqlserver.port
             try:
                 self._mysql_cnx = PyMysqlPool.mysql.connector.connect(**dbconfig)
+                cnx.start_transaction(
+                    consistent_snapshot=dbconfig.get('consistent_snapshot', False),
+                    isolation_level=dbconfig.get('isolation_level', None),
+                    readonly=dbconfig.get('readonly', None),
+                )
             except Error as exc:
                 if counter == attempts:
                     self.reset_cache(mysqlserver.group)

--- a/PyMysqlPool/mysql/connector/flask/mysql.py
+++ b/PyMysqlPool/mysql/connector/flask/mysql.py
@@ -55,6 +55,12 @@ class MySQL(object):
             self.connect_args['use_unicode'] = self.app.config['MYSQL_USE_UNICODE']
         if self.app.config['MYSQL_USE_POOL']:
             self.connect_args['pool'] = self.app.config['MYSQL_USE_POOL']
+        if self.app.config['MYSQL_CONSISTENT_SNAPSHOT']:
+            self.connect_args['consistent_snapshot'] = self.app.config['MYSQL_CONSISTENT_SNAPSHOT']
+        if self.app.config['MYSQL_ISOLATION_LEVEL']:
+            self.connect_args['isolation_level'] = self.app.config['MYSQL_ISOLATION_LEVEL']
+        if self.app.config['MYSQL_READONLY']:
+            self.connect_args['readonly'] = self.app.config['MYSQL_READONLY']
         return get_pool_conn_implicitly(self.connect_args)
 
     def teardown_request(self, exception):

--- a/README.rst
+++ b/README.rst
@@ -78,6 +78,7 @@ The following  prototype_ pool examples below:
             'host': "10.95.130.***", 'port': 8899,
             'user': "root", 'passwd': "****",
             'db': "marry", 'charset': "utf8",
+            'isolation_level': 'READ COMMITTED',
             'pool': {
                 #use = 0 no pool else use pool
                 "use":1,
@@ -175,6 +176,7 @@ The following  prototype_ pool examples below:
         'HOST': '10.95.130.***',
         'PORT': '8899',
         'OPTIONS': {
+            'isolation_level': 'READ COMMITTED',
             'autocommit': True,
             'pool': {
                 #use = 0 no pool else use pool
@@ -206,6 +208,7 @@ The following  prototype_ pool examples below:
         MYSQL_DATABASE_USER='root',
         MYSQL_DATABASE_PASSWORD='******',
         MYSQL_DATABASE_DB='flask',
+        MYSQL_ISOLATION_LEVEL='READ COMMITTED',
         MYSQL_USE_POOL=
         {
             #use = 0 no pool else use pool


### PR DESCRIPTION
## Description
Add support to call `start_transaction` function after the connection is established. This allows setting the isolation level as well. As the documentation says:
>This method explicitly starts a transaction sending the
START TRANSACTION statement to the MySQL server. You can optionally
set whether there should be a consistent snapshot, which
isolation level you need or which access mode i.e. READ ONLY or
READ WRITE. Raises ProgrammingError when a transaction is already in progress
and when ValueError when isolation_level specifies an Unknown
level.

## Context
Currently, it is not possible to set the `isolation level` when the connection established, though `start_transaction` function could support setting isolation level.